### PR TITLE
Add an option flag to not display icons but text instead

### DIFF
--- a/gods.go
+++ b/gods.go
@@ -22,6 +22,27 @@ import (
 	"time"
 )
 
+const (
+	netDev = "eth0"
+
+	bpsSign   = "á"
+	kibpsSign = "â"
+	mibpsSign = "ã"
+
+	unpluggedSign = "è"
+	pluggedSign   = "é"
+
+	cpuSign = "Ï"
+	memSign = "Þ"
+
+	netReceivedSign    = "Ð"
+	netTransmittedSign = "Ñ"
+
+	floatSeparator = "à"
+	dateSeparator  = "Ý"
+	fieldSeparator = "û"
+)
+
 var (
 	cores = runtime.NumCPU() // count of cores to scale cpu usage
 	rxOld = 0
@@ -35,20 +56,22 @@ func fixed(pre string, rate int) string {
 	}
 
 	var spd = float32(rate)
-	var suf = "á" // default: display as B/s
+	var suf = bpsSign // default: display as B/s
+
 	switch {
 	case spd >= (1000 * 1024 * 1024): // > 999 MiB/s
 		return "" + pre + "ERR"
 	case spd >= (1000 * 1024): // display as MiB/s
 		spd /= (1024 * 1024)
-		suf = "ã"
+		suf = mibpsSign
 		pre = "" + pre + ""
 	case spd >= 1000: // display as KiB/s
 		spd /= 1024
-		suf = "â"
+		suf = kibpsSign
 	}
 
 	var formated = ""
+
 	if spd >= 100 {
 		formated = fmt.Sprintf("%3.0f", spd)
 	} else if spd >= 10 {
@@ -56,32 +79,36 @@ func fixed(pre string, rate int) string {
 	} else {
 		formated = fmt.Sprintf(" %3.1f", spd)
 	}
-	return pre + strings.Replace(formated, ".", "à", 1) + suf
+
+	return pre + strings.Replace(formated, ".", floatSeparator, 1) + suf
 }
 
 // updateNetUse reads current transfer rates of certain network interfaces
 func updateNetUse() string {
 	file, err := os.Open("/proc/net/dev")
+
 	if err != nil {
-		return "Ð ERR Ñ ERR"
+		return netReceivedSign + " ERR " + netTransmittedSign + " ERR"
 	}
 	defer file.Close()
 
 	var void = 0 // target for unused values
 	var dev, rx, tx, rxNow, txNow = "", 0, 0, 0, 0
 	var scanner = bufio.NewScanner(file)
+
 	for scanner.Scan() {
 		_, err = fmt.Sscanf(scanner.Text(), "%s %d %d %d %d %d %d %d %d %d",
 			&dev, &rx, &void, &void, &void, &void, &void, &void, &void, &tx)
+
 		switch dev { // ignore devices like tun, tap, lo, ...
-		case "eth0:", "eth1:", "wlan0:", "ppp0:":
+		case "ppp0:", "eth1:", "wlan0:", netDev + ":":
 			rxNow += rx
 			txNow += tx
 		}
 	}
 
 	defer func() { rxOld, txOld = rxNow, txNow }()
-	return fmt.Sprintf("%s %s", fixed("Ð", rxNow-rxOld), fixed("Ñ", txNow-txOld))
+	return fmt.Sprintf("%s %s", fixed(netReceivedSign, rxNow-rxOld), fixed(netTransmittedSign, txNow-txOld))
 }
 
 // colored surrounds the percentage with color escapes if it is >= 70
@@ -126,6 +153,7 @@ func updatePower() string {
 
 	for _, batt := range batts {
 		name := batt.Name()
+
 		if !strings.HasPrefix(name, "BAT") {
 			continue
 		}
@@ -139,9 +167,10 @@ func updatePower() string {
 	}
 
 	enPerc = enNow * 100 / enFull
-	var icon = "è"
+	var icon = unpluggedSign
+
 	if string(plugged) == "1\n" {
-		icon = "é"
+		icon = pluggedSign
 	}
 
 	if enPerc <= 5 {
@@ -156,30 +185,35 @@ func updatePower() string {
 func updateCPUUse() string {
 	var load float32
 	var loadavg, err = ioutil.ReadFile("/proc/loadavg")
+
 	if err != nil {
-		return "ÏERR"
+		return cpuSign + "ERR"
 	}
+
 	_, err = fmt.Sscanf(string(loadavg), "%f", &load)
+
 	if err != nil {
-		return "ÏERR"
+		return cpuSign + "ERR"
 	}
-	return colored("Ï", int(load*100.0/float32(cores)))
+
+	return colored(cpuSign, int(load*100.0/float32(cores)))
 }
 
 // updateMemUse reads the memory used by applications and scales to [0, 100]
 func updateMemUse() string {
 	var file, err = os.Open("/proc/meminfo")
 	if err != nil {
-		return "ÞERR"
+		return memSign + "ERR"
 	}
 	defer file.Close()
 
 	// done must equal the flag combination (0001 | 0010 | 0100 | 1000) = 15
 	var total, used, done = 0, 0, 0
+
 	for info := bufio.NewScanner(file); done != 15 && info.Scan(); {
 		var prop, val = "", 0
 		if _, err = fmt.Sscanf(info.Text(), "%s %d", &prop, &val); err != nil {
-			return "ÞERR"
+			return memSign + "ERR"
 		}
 		switch prop {
 		case "MemTotal:":
@@ -197,24 +231,34 @@ func updateMemUse() string {
 			done |= 8
 		}
 	}
-	return colored("Þ", used*100/total)
+	return colored(memSign, used*100/total)
+}
+
+func getHostname() (hostname string) {
+	if tmp, err := ioutil.ReadFile("/etc/hostname"); err == nil {
+		hostname = strings.TrimSpace(string(tmp))
+	}
+
+	return
 }
 
 // main updates the dwm statusbar every second
 func main() {
 	for {
 		var status = []string{
-			"",
+			getHostname(),
 			updateNetUse(),
 			updateCPUUse(),
 			updateMemUse(),
 			updatePower(),
-			time.Now().Local().Format("Mon 02 Ý 15:04:05"),
+			time.Now().Local().Format("Mon 02 " + dateSeparator + " 15:04:05"),
 		}
-		exec.Command("xsetroot", "-name", strings.Join(status, "û")).Run()
+
+		exec.Command("xsetroot", "-name", strings.Join(status, fieldSeparator)).Run()
 
 		// sleep until beginning of next second
 		var now = time.Now()
+
 		time.Sleep(now.Truncate(time.Second).Add(time.Second).Sub(now))
 	}
 }


### PR DESCRIPTION
I didn't want to set up the font (sorry :D) so I translated everything as text. It's now just an option when you start the daemon (`-text`).

Also, I had a strange device name for my wifi card so I added an option to specify a different dev name (`-dev`).

To finish, instead of an empty string at the beginning, I'm displaying the machine's hostname.

Comments are more than welcome.
